### PR TITLE
FormInputs: add the plaintext and password inputs for now.

### DIFF
--- a/lib/design-hs-lib.cabal
+++ b/lib/design-hs-lib.cabal
@@ -94,6 +94,7 @@ library
     Smart.Html.Checkbox 
     Smart.Html.Form 
     Smart.Html.Textarea  
+    Smart.Html.Input
     Smart.Html.Loader  
     Smart.Html.Navbar
     Smart.Html.Wizard   

--- a/lib/src/Smart/Html/Button.hs
+++ b/lib/src/Smart/Html/Button.hs
@@ -73,7 +73,7 @@ mkButton
   -> H.Html
 mkButton mEnabled mIconL mTitle mIconR specificClass =
   maybe identity elemEnabledStateAttr mEnabled
-    .  (H.button ! A.class_ ("c-button " <> specificClass) ! A.type_ "button")
+    .  (H.button ! A.class_ ("c-button " <> specificClass))
     $  iconL
     *> span
     <* iconR

--- a/lib/src/Smart/Html/Form.hs
+++ b/lib/src/Smart/Html/Form.hs
@@ -1,32 +1,16 @@
 module Smart.Html.Form
   ( FormGroup(..)
-  , FormInput(..)
   ) where
 
 import           Control.Lens
 import qualified Data.Text                     as T
 import qualified Smart.Html.Checkbox           as C
+import qualified Smart.Html.Input              as Inp
 import qualified Smart.Html.Shared.Types       as Types
 import qualified Smart.Html.Textarea           as TA
 import qualified Text.Blaze.Html5              as H
 import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
-
-data FormInput =
-  TextInput Types.Id (Maybe Text)
-  | PasswordInput Types.Id (Maybe Text)
-  deriving Show
-
-instance H.ToMarkup FormInput where
-  toMarkup = \case
-    TextInput     id mDefault -> mkInput id "text" & addDefault mDefault
-    PasswordInput id mDefault -> mkInput id "password" & addDefault mDefault
-   where
-    mkInput (Types.Id id) type_ =
-      H.input ! A.class_ "o-form-input" ! A.type_ type_ ! A.id (H.toValue id)-- & (! maybe identity (A.value) mDefault)
-    addDefault mDefault input = case mDefault of
-      Nothing   -> input
-      Just def' -> input ! A.value (H.textValue def')
 
 -- | Group of form inputs. 
 data FormGroup =
@@ -34,7 +18,7 @@ data FormGroup =
   | CheckboxGroupInline Types.Title [C.Checkbox]
   -- | A group of text area. 
   | TextareaGroup [(Types.Title, TA.Textarea)]
-  | InputGroup [(Types.Title, FormInput)]
+  | InputGroup [(Types.Title, Inp.TextInput)]
   deriving Show
 
 instance H.ToMarkup FormGroup where
@@ -54,8 +38,8 @@ instance H.ToMarkup FormGroup where
         <$> labelsAndInputs
      where
       getInputId = Just . \case
-        TextInput     id _ -> id
-        PasswordInput id _ -> id
+        Inp.PlainTextInput _ id _ -> id
+        Inp.PasswordInput  _ id _ -> id
 
    where
     drawCheckboxes mExtraClass title checkboxes =

--- a/lib/src/Smart/Html/Form.hs
+++ b/lib/src/Smart/Html/Form.hs
@@ -38,8 +38,8 @@ instance H.ToMarkup FormGroup where
         <$> labelsAndInputs
      where
       getInputId = Just . \case
-        Inp.PlainTextInput _ id _ -> id
-        Inp.PasswordInput  _ id _ -> id
+        Inp.PlainTextInput _ id _ _ -> id
+        Inp.PasswordInput  _ id _ _ -> id
 
    where
     drawCheckboxes mExtraClass title checkboxes =

--- a/lib/src/Smart/Html/Input.hs
+++ b/lib/src/Smart/Html/Input.hs
@@ -1,0 +1,26 @@
+module Smart.Html.Input
+  ( TextInput(..)
+  ) where
+
+import qualified Smart.Html.Shared.Types       as Types
+import qualified Text.Blaze.Html5              as H
+import           Text.Blaze.Html5               ( (!) )
+import qualified Text.Blaze.Html5.Attributes   as A
+
+-- | A simple text input. 
+data TextInput = PlainTextInput Types.ElemEnabledState Types.Id (Maybe Text)
+               | PasswordInput Types.ElemEnabledState Types.Id (Maybe Text)
+               deriving (Eq, Show)
+
+instance H.ToMarkup TextInput where
+  toMarkup = \case
+    PlainTextInput state' id mval -> mkInput state' "text" id mval
+    PasswordInput  state' id mval -> mkInput state' "password" id mval
+   where
+    mkInput state' type' id mval =
+      Types.elemEnabledStateAttr state'
+        $ H.input
+        ! A.type_ type'
+        ! addValue
+        ! Types.id id
+      where addValue = maybe mempty (A.value . H.textValue) mval

--- a/lib/src/Smart/Html/Input.hs
+++ b/lib/src/Smart/Html/Input.hs
@@ -21,6 +21,7 @@ instance H.ToMarkup TextInput where
       Types.elemEnabledStateAttr state'
         $ H.input
         ! A.type_ type'
+        ! A.class_ "c-input"
         ! addValue
         ! Types.id id
       where addValue = maybe mempty (A.value . H.textValue) mval

--- a/lib/src/Smart/Html/Input.hs
+++ b/lib/src/Smart/Html/Input.hs
@@ -8,20 +8,21 @@ import           Text.Blaze.Html5               ( (!) )
 import qualified Text.Blaze.Html5.Attributes   as A
 
 -- | A simple text input. 
-data TextInput = PlainTextInput Types.ElemEnabledState Types.Id (Maybe Text)
-               | PasswordInput Types.ElemEnabledState Types.Id (Maybe Text)
+data TextInput = PlainTextInput Types.ElemEnabledState Types.Id Types.Name (Maybe Text)
+               | PasswordInput Types.ElemEnabledState Types.Id Types.Name (Maybe Text)
                deriving (Eq, Show)
 
 instance H.ToMarkup TextInput where
   toMarkup = \case
-    PlainTextInput state' id mval -> mkInput state' "text" id mval
-    PasswordInput  state' id mval -> mkInput state' "password" id mval
+    PlainTextInput state' id name mval -> mkInput state' "text" id name mval
+    PasswordInput  state' id name mval -> mkInput state' "password" id name mval
    where
-    mkInput state' type' id mval =
+    mkInput state' type' id (Types.Name name) mval =
       Types.elemEnabledStateAttr state'
         $ H.input
         ! A.type_ type'
         ! A.class_ "c-input"
         ! addValue
         ! Types.id id
+        ! A.name (H.textValue name)
       where addValue = maybe mempty (A.value . H.textValue) mval


### PR DESCRIPTION
@thusc we never got around to implementing inputs, AFAICS, so I've
added some basic implementation for now.

This is needed in the prototype-hs-example implementation for the
login.

I've not been able to complete the full login implementation.
